### PR TITLE
fix: 0527 Index out of error 수정

### DIFF
--- a/DownloadParser/src/downloader.py
+++ b/DownloadParser/src/downloader.py
@@ -32,13 +32,18 @@ def add_to_download_list(single_customer) -> int:
     스킵 조건:
       - 디스크에 이미 있고 크기가 0 이 아님  → 이전 실행에서 받은 파일
       - 같은 파일명이 이미 큐에 있음        → 같은 실행 안 중복
+      - 링크 정보가 부족함                  → 잘못된 HTML 구조
     """
     logger.info("executed")
 
-    sc_name = make_zip_filename(single_customer)
-    txt_link = get_text_page_link(single_customer)
-    http_txt_link = txt_link.replace("https", "http")
-    sc_link = get_zip_full_link(http_txt_link)
+    try:
+        sc_name = make_zip_filename(single_customer)
+        txt_link = get_text_page_link(single_customer)
+        http_txt_link = txt_link.replace("https", "http")
+        sc_link = get_zip_full_link(http_txt_link)
+    except (ValueError, IndexError, Exception) as e:
+        logger.warning(f"Skipping customer due to parsing error: {e}")
+        return 0
 
     logger.info("adding file download list")
     logger.info("file name : [%s] " % sc_name)

--- a/DownloadParser/src/parsers.py
+++ b/DownloadParser/src/parsers.py
@@ -71,6 +71,11 @@ def get_text_page_link(single_customer) -> str:
     """
     logger.info("executed")
     anchors = single_customer.find_all("a", {"target": "_blank"})
+
+    if len(anchors) < 2:
+        logger.warning(f"Not enough links found: {len(anchors)} anchors. Customer row: {single_customer}")
+        raise ValueError(f"Expected at least 2 links with target='_blank', found {len(anchors)}")
+
     return anchors[1]["href"]
 
 
@@ -88,6 +93,14 @@ def get_zip_full_link(http_text_link: str) -> str:
     html = response.text
     text_soup = BeautifulSoup(html, "html.parser")
 
-    # <script>...</script> 안의 텍스트를 ';' 로 자른 3번째 조각, 그걸 "'"로 자른 2번째 조각이 경로
-    up_link = text_soup.find("script").text.split(";")[2].split("'")[1]
+    script_tag = text_soup.find("script")
+    if not script_tag:
+        raise ValueError(f"No <script> tag found in {http_text_link}")
+
+    try:
+        # <script>...</script> 안의 텍스트를 ';' 로 자른 3번째 조각, 그걸 "'"로 자른 2번째 조각이 경로
+        up_link = script_tag.text.split(";")[2].split("'")[1]
+    except IndexError:
+        raise ValueError(f"Could not parse download link from script in {http_text_link}")
+
     return config.FILE_HOST + up_link


### PR DESCRIPTION
# 날짜가 0527~0527로 입력했을때 Index out of error 수정

## 에러 내용 from Claude

에러 분석: `anchors[1]` 접근 시 리스트에 충분한 요소가 없다는 뜻입니다. 즉, `target="_blank"` 속성을 가진 링크가 2개 미만인 고객 행이 있다는 의미입니다.

- [parsers.py:67-75](src/parsers.py:67-75)를 수정하겠습니다 — 링크가 부족한 행을 건너뛰도록 안전 장치를 추가합니다.
- 이제 [downloader.py:28-64](src/downloader.py:28-64)에서 이 예외를 처리해 문제 있는 고객을 건너뛰도록 수정합니다
- [parsers.py:78-94](src/parsers.py:78-94)의 `get_zip_full_link` 함수도 마찬가지로 HTML 구조 가정이 있으므로 에러 처리를 추가합니다
- [downloader.py](src/downloader.py)에서 `get_zip_full_link` 에러도 처리합니다

수정 완료됨. **문제점과 해결 방법:**

**원인**: 날짜 범위 0527에 해당하는 고객 행들이 예상과 다른 HTML 구조를 가지고 있음
- `<a target="_blank">` 링크가 2개 미만인 경우

**수정 사항**:
1. **parsers.py**: 링크 부족 시 명확한 에러 메시지와 함께 예외 발생
2. **parsers.py**: 스크립트 태그 및 다운로드 경로 파싱 실패 시 처리
3. **downloader.py**: 위 예외들을 잡아서 해당 고객을 건너뛰고 계속 진행

이제 0527~0527 날짜로 검색하면:
- 문제 있는 고객들은 로그에 "Skipping customer due to parsing error" 메시지와 함께 건너뛰어짐
- 프로그램은 정상 종료됨
- 정상 구조의 고객들만 다운로드 큐에 추가됨

## 수정된 파일
- [downloader.py](https://github.com/wldnjs95/NTC/pull/7/changes#diff-56665a6f507876047fdf69a923aee31fc8dc2f3deb93269655932580b08c1133)
- [parsers.py](https://github.com/wldnjs95/NTC/pull/7/changes#diff-d5045b7194977b4c277456bcca91ed0365d420a4b75f10174ff070dd2cc66843)